### PR TITLE
[✨feat]: 상단바 구현

### DIFF
--- a/src/app/createstudy/page.tsx
+++ b/src/app/createstudy/page.tsx
@@ -9,6 +9,7 @@ import CountInput from '@/components/common/CountInput';
 import { Input } from '@/components/common/Input';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import MultiSelect from '@/components/common/MultiSelect';
+import NavHeader from '@/components/common/NavHeader';
 interface FormData {
   jobPosition: string[];
   topic: string;
@@ -54,219 +55,222 @@ const CreateStudyPage = () => {
   };
 
   return (
-    <div className="max-w-2xl mx-auto py-4">
-      {isLoading ? (
-        <LoadingSpinner message="모집글 발행중..." />
-      ) : (
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-          <div className="px-4">
-            <label className="text-sm font-medium text-gray-700 mb-1">
-              모집 직군
-            </label>
-            <MultiSelect
-              items={jobItems}
-              selectedIds={selectedJobIds}
-              onSelectionChange={handleJobsChange}
-              placeholder="직군 선택"
-              title="모집 직군 선택"
-            />
-          </div>
+    <div>
+      <NavHeader title="스터디 만들기" />
+      <div className="max-w-2xl mx-auto py-4">
+        {isLoading ? (
+          <LoadingSpinner message="모집글 발행중..." />
+        ) : (
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            <div className="px-4">
+              <label className="text-sm font-medium text-gray-700 mb-1">
+                모집 직군
+              </label>
+              <MultiSelect
+                items={jobItems}
+                selectedIds={selectedJobIds}
+                onSelectionChange={handleJobsChange}
+                placeholder="직군 선택"
+                title="모집 직군 선택"
+              />
+            </div>
 
-          <Controller
-            name="topic"
-            control={control}
-            rules={{ required: '주제를 입력하세요' }}
-            defaultValue=""
-            render={({ field: { ref, ...restField } }) => (
-              <div className="px-4">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  주제
-                </label>
-                <CountInput
-                  inputType="input"
-                  placeholder="주제를 입력하세요"
-                  maxCount={20}
-                  {...restField}
-                  ref={ref}
-                />
-                {errors.topic && (
-                  <p className="text-red-500 text-sm mt-1">
-                    {errors.topic.message}
-                  </p>
-                )}
-              </div>
-            )}
-          />
-
-          <Controller
-            name="goal"
-            control={control}
-            rules={{ required: '목표를 입력하세요' }}
-            defaultValue=""
-            render={({ field: { ref, ...restField } }) => (
-              <div className="px-4">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  목표
-                </label>
-                <CountInput
-                  inputType="input"
-                  placeholder="목표를 입력하세요"
-                  maxCount={20}
-                  {...restField}
-                  ref={ref}
-                />
-                {errors.goal && (
-                  <p className="text-red-500 text-sm mt-1">
-                    {errors.goal.message}
-                  </p>
-                )}
-              </div>
-            )}
-          />
-
-          <Controller
-            name="introduction"
-            control={control}
-            defaultValue=""
-            render={({ field: { ref, ...restField } }) => (
-              <div className="px-4">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  소개
-                </label>
-                <CountInput
-                  inputType="textarea"
-                  className="resize-none"
-                  placeholder="소개 내용을 입력하세요"
-                  maxCount={200}
-                  rows={4}
-                  {...restField}
-                  ref={ref}
-                />
-              </div>
-            )}
-          />
-
-          <Controller
-            name="methodAndCurriculum"
-            control={control}
-            defaultValue=""
-            render={({ field: { ref, ...restField } }) => (
-              <div className="px-4">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  진행방식과 커리큘럼
-                </label>
-                <CountInput
-                  inputType="textarea"
-                  className="resize-none"
-                  placeholder="스터디를 설명해주세요"
-                  maxCount={500}
-                  rows={6}
-                  {...restField}
-                  ref={ref}
-                />
-              </div>
-            )}
-          />
-
-          <div className="flex gap-3 px-4">
             <Controller
-              name="startDate"
+              name="topic"
               control={control}
+              rules={{ required: '주제를 입력하세요' }}
               defaultValue=""
-              render={({ field }) => (
-                <div className="flex flex-col flex-auto">
-                  <label className="text-sm font-medium text-gray-700 mb-1">
-                    시작일
+              render={({ field: { ref, ...restField } }) => (
+                <div className="px-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    주제
                   </label>
-                  <Input className="w-full" type="date" {...field} />
+                  <CountInput
+                    inputType="input"
+                    placeholder="주제를 입력하세요"
+                    maxCount={20}
+                    {...restField}
+                    ref={ref}
+                  />
+                  {errors.topic && (
+                    <p className="text-red-500 text-sm mt-1">
+                      {errors.topic.message}
+                    </p>
+                  )}
                 </div>
               )}
             />
 
             <Controller
-              name="endDate"
+              name="goal"
               control={control}
+              rules={{ required: '목표를 입력하세요' }}
               defaultValue=""
-              render={({ field }) => (
-                <div className="flex flex-col flex-auto">
-                  <label className="text-sm font-medium text-gray-700 mb-1">
-                    종료일
+              render={({ field: { ref, ...restField } }) => (
+                <div className="px-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    목표
                   </label>
-                  <Input className="w-full" type="date" {...field} />
+                  <CountInput
+                    inputType="input"
+                    placeholder="목표를 입력하세요"
+                    maxCount={20}
+                    {...restField}
+                    ref={ref}
+                  />
+                  {errors.goal && (
+                    <p className="text-red-500 text-sm mt-1">
+                      {errors.goal.message}
+                    </p>
+                  )}
                 </div>
               )}
             />
-          </div>
 
-          <Controller
-            name="regularMeeting"
-            control={control}
-            defaultValue=""
-            render={({ field }) => (
-              <div className="px-4">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  정기적 모임
-                </label>
-                <Input
-                  className="w-full"
-                  type="text"
-                  placeholder="예: 매주 수요일 20시"
-                  {...field}
-                />
-              </div>
-            )}
-          />
-
-          <Controller
-            name="studyRecruitmentNumber"
-            control={control}
-            defaultValue={1}
-            render={({ field }) => (
-              <div className="px-4">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  스터디 모집 인원
-                </label>
-                <Input className="w-full" type="number" {...field} />
-              </div>
-            )}
-          />
-
-          <Controller
-            name="tags"
-            control={control}
-            defaultValue=""
-            render={({ field }) => (
-              <div className="px-4">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  관련 태그
-                </label>
-                <Input
-                  className="w-full"
-                  type="text"
-                  placeholder="태그를 입력하세요"
-                  {...field}
-                />
-              </div>
-            )}
-          />
-          <div className="flex gap-3 sticky bottom-[62px] left-1/2 w-full max-w-2xl bg-white/10 backdrop-blur-sm p-4 border-t border-[#CCCEF0]">
-            <Button
-              label="이전"
-              bgColor="bg-white"
-              textColor="text-[#CED4DA]"
-              className="w-1/3 h-12 border-2"
-              onClick={() => console.log('이전 버튼 클릭됨')}
+            <Controller
+              name="introduction"
+              control={control}
+              defaultValue=""
+              render={({ field: { ref, ...restField } }) => (
+                <div className="px-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    소개
+                  </label>
+                  <CountInput
+                    inputType="textarea"
+                    className="resize-none"
+                    placeholder="소개 내용을 입력하세요"
+                    maxCount={200}
+                    rows={4}
+                    {...restField}
+                    ref={ref}
+                  />
+                </div>
+              )}
             />
 
-            <Button
-              label="작성완료"
-              type="submit"
-              onClick={() => console.log('다음 버튼 클릭됨')}
-              className="w-2/3 h-12"
+            <Controller
+              name="methodAndCurriculum"
+              control={control}
+              defaultValue=""
+              render={({ field: { ref, ...restField } }) => (
+                <div className="px-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    진행방식과 커리큘럼
+                  </label>
+                  <CountInput
+                    inputType="textarea"
+                    className="resize-none"
+                    placeholder="스터디를 설명해주세요"
+                    maxCount={500}
+                    rows={6}
+                    {...restField}
+                    ref={ref}
+                  />
+                </div>
+              )}
             />
-          </div>
-        </form>
-      )}
+
+            <div className="flex gap-3 px-4">
+              <Controller
+                name="startDate"
+                control={control}
+                defaultValue=""
+                render={({ field }) => (
+                  <div className="flex flex-col flex-auto">
+                    <label className="text-sm font-medium text-gray-700 mb-1">
+                      시작일
+                    </label>
+                    <Input className="w-full" type="date" {...field} />
+                  </div>
+                )}
+              />
+
+              <Controller
+                name="endDate"
+                control={control}
+                defaultValue=""
+                render={({ field }) => (
+                  <div className="flex flex-col flex-auto">
+                    <label className="text-sm font-medium text-gray-700 mb-1">
+                      종료일
+                    </label>
+                    <Input className="w-full" type="date" {...field} />
+                  </div>
+                )}
+              />
+            </div>
+
+            <Controller
+              name="regularMeeting"
+              control={control}
+              defaultValue=""
+              render={({ field }) => (
+                <div className="px-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    정기적 모임
+                  </label>
+                  <Input
+                    className="w-full"
+                    type="text"
+                    placeholder="예: 매주 수요일 20시"
+                    {...field}
+                  />
+                </div>
+              )}
+            />
+
+            <Controller
+              name="studyRecruitmentNumber"
+              control={control}
+              defaultValue={1}
+              render={({ field }) => (
+                <div className="px-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    스터디 모집 인원
+                  </label>
+                  <Input className="w-full" type="number" {...field} />
+                </div>
+              )}
+            />
+
+            <Controller
+              name="tags"
+              control={control}
+              defaultValue=""
+              render={({ field }) => (
+                <div className="px-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    관련 태그
+                  </label>
+                  <Input
+                    className="w-full"
+                    type="text"
+                    placeholder="태그를 입력하세요"
+                    {...field}
+                  />
+                </div>
+              )}
+            />
+            <div className="flex gap-3 sticky bottom-[62px] left-1/2 w-full max-w-2xl bg-white/10 backdrop-blur-sm p-4 border-t border-[#CCCEF0]">
+              <Button
+                label="이전"
+                bgColor="bg-white"
+                textColor="text-[#CED4DA]"
+                className="w-1/3 h-12 border-2"
+                onClick={() => console.log('이전 버튼 클릭됨')}
+              />
+
+              <Button
+                label="작성완료"
+                type="submit"
+                onClick={() => console.log('다음 버튼 클릭됨')}
+                className="w-2/3 h-12"
+              />
+            </div>
+          </form>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/app/pending-request/page.tsx
+++ b/src/app/pending-request/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import BottomButton from '@/components/common/BottomButton';
+import NavHeader from '@/components/common/NavHeader';
 import PendingProfileCard from '@/components/common/PendingProfileCard';
 
 interface ProfileDatas {
@@ -46,9 +47,6 @@ const PendingRequest = () => {
   const [acceptedCount, setAcceptedCount] = useState(0);
   const [totalCount, setTotalCount] = useState(4);
 
-  const handleLeftClick = () => {
-    router.back();
-  };
   const handleReject = (id: string) => {
     //해당 참여요청 거절버튼 클릭
     setProfileData((profiles) =>
@@ -82,32 +80,11 @@ const PendingRequest = () => {
 
   return (
     <div>
+      <NavHeader title="대기중인 요청" />
       <div className="flex justify-center items-center h-auto ">
-        <div className="flex items-center flex-col w-[21.438rem] space-y-5">
+        <div className="flex items-center flex-col w-[21.438rem] ">
           <div className="relative text-center space-y-5 ">
-            <div className="sticky top-0 flex items-center justify-center">
-              {/* 이전 페이지로 이동 */}
-              <button onClick={handleLeftClick} className="fixed left-0">
-                <svg
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="cursor-pointer">
-                  <path
-                    fillRule="evenodd"
-                    clipRule="evenodd"
-                    d="M15.5303 3.96967C15.8232 4.26256 15.8232 4.73744 15.5303 5.03033L8.56066 12L15.5303 18.9697C15.8232 19.2626 15.8232 19.7374 15.5303 20.0303C15.2374 20.3232 14.7626 20.3232 14.4697 20.0303L6.96967 12.5303C6.67678 12.2374 6.67678 11.7626 6.96967 11.4697L14.4697 3.96967C14.7626 3.67678 15.2374 3.67678 15.5303 3.96967Z"
-                    fill="black"
-                    fillOpacity="0.8"
-                  />
-                </svg>
-              </button>
-
-              <div className="font-bold text-lg mx-auto">대기중인 요청</div>
-            </div>
-            <hr className="w-[24.125rem] border-1 border-greyBorder mt-5 mb-5" />
+            {/* <hr className="w-[24.125rem] border-1 border-greyBorder mt-5 mb-5" /> */}
           </div>
 
           <PendingProfileCard

--- a/src/app/postdetail/page.tsx
+++ b/src/app/postdetail/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import Avatar from '@/components/common/Avatar';
 import BottomButton from '@/components/common/BottomButton';
+import NavHeader from '@/components/common/NavHeader';
 import TagBox from '@/components/common/TagBox';
 import { View } from '@/components/icons/View';
 
@@ -14,75 +15,80 @@ const PostDetailPage = () => {
   const tagData = ['Figma', 'UI/UX', '디자이너', '온라인 강의'];
 
   return (
-    <div className="flex flex-col gap-5 px-3 py-3">
-      <div className="flex items-center gap-4">
-        <h1 className="text-xl font-bold">피그마 정복하기</h1>
-        <span className="border-primary border-[2px] text-primary text-sm font-medium px-3 py-0.5 rounded-2xl">
-          D-13
-        </span>
-      </div>
-      {/* TagList */}
-      <div className="flex gap-3">
-        {tagData.map((tag, idx) => (
-          <TagBox key={idx}>{tag}</TagBox>
-        ))}
-      </div>
-      {/* Info */}
-      <div className="flex items-center gap-4">
-        <Avatar />
-        <div className="flex flex-col gap-1 text-sm w-full">
-          <span className="font-medium text-gray-800">김서희</span>
-          <div className="flex justify-between w-full text-[#908794]">
-            <div className="flex items-center space-x-2">
-              <p>작성일 24.06.07</p>
-              <span>|</span>
-              <p>09:41</p>
-              <span>|</span>
-              <p>조회수 33</p>
-            </div>
-            <div className="flex items-center gap-[.1875rem]">
-              <View />
-              <p>1,203</p>
+    <div>
+      <NavHeader />
+      <div className="flex flex-col gap-5 px-3 py-3">
+        <div className="flex items-center gap-4">
+          <h1 className="text-xl font-bold">피그마 정복하기</h1>
+          <span className="border-primary border-[2px] text-primary text-sm font-medium px-3 py-0.5 rounded-2xl">
+            D-13
+          </span>
+        </div>
+        {/* TagList */}
+        <div className="flex gap-3">
+          {tagData.map((tag, idx) => (
+            <TagBox key={idx}>{tag}</TagBox>
+          ))}
+        </div>
+        {/* Info */}
+        <div className="flex items-center gap-4">
+          <Avatar />
+          <div className="flex flex-col gap-1 text-sm w-full">
+            <span className="font-medium text-gray-800">김서희</span>
+            <div className="flex justify-between w-full text-[#908794]">
+              <div className="flex items-center space-x-2">
+                <p>작성일 24.06.07</p>
+                <span>|</span>
+                <p>09:41</p>
+                <span>|</span>
+                <p>조회수 33</p>
+              </div>
+              <div className="flex items-center gap-[.1875rem]">
+                <View />
+                <p>1,203</p>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <hr className="border border-greyBorder" />
+        <hr className="border border-greyBorder" />
 
-      {/* Study Details */}
-      <div>
-        <h2 className="font-semibold text-gray-800">스터디 주제</h2>
-        <p className="text-gray-600">콜로소 피그마 UX/UI 디자인 강의 스터디</p>
-      </div>
+        {/* Study Details */}
+        <div>
+          <h2 className="font-semibold text-gray-800">스터디 주제</h2>
+          <p className="text-gray-600">
+            콜로소 피그마 UX/UI 디자인 강의 스터디
+          </p>
+        </div>
 
-      <div>
-        <h2 className="font-semibold text-gray-800">스터디 목표</h2>
-        <p className="text-gray-600">강의 완주 후 학습 네트워킹</p>
-      </div>
+        <div>
+          <h2 className="font-semibold text-gray-800">스터디 목표</h2>
+          <p className="text-gray-600">강의 완주 후 학습 네트워킹</p>
+        </div>
 
-      <div>
-        <h2 className="font-semibold text-gray-800">스터디 소개</h2>
-        <p className="text-gray-600">
-          디자인에서 필수적인 피그마 툴 학습을 함께 배우고 강의 내용을 응용하여
-          UI를 제작해 인증하는 방식으로 진행하고 있어요. 피드백을 주고 받으며
-          학습 내용을 공유해봐요!
-        </p>
-      </div>
+        <div>
+          <h2 className="font-semibold text-gray-800">스터디 소개</h2>
+          <p className="text-gray-600">
+            디자인에서 필수적인 피그마 툴 학습을 함께 배우고 강의 내용을
+            응용하여 UI를 제작해 인증하는 방식으로 진행하고 있어요. 피드백을
+            주고 받으며 학습 내용을 공유해봐요!
+          </p>
+        </div>
 
-      <div>
-        <h2 className="font-semibold text-gray-800">스터디 기간</h2>
-        <p className="text-gray-600">2024.06.19 (토) - 07.19(토)</p>
-        <p className="text-gray-600">매주 토요일 오후 1시 - 3시</p>
-      </div>
-      <div className="flex flxed bottom-0 w-full justify-center items-center ">
-        <BottomButton
-          label="대기 중인 요청 확인하기"
-          acceptedCount={acceptedCount}
-          totalCount={totalCount}
-          onClick={() => {
-            router.push('/pending-request');
-          }}
-        />
+        <div>
+          <h2 className="font-semibold text-gray-800">스터디 기간</h2>
+          <p className="text-gray-600">2024.06.19 (토) - 07.19(토)</p>
+          <p className="text-gray-600">매주 토요일 오후 1시 - 3시</p>
+        </div>
+        <div className="flex flxed bottom-0 w-full justify-center items-center ">
+          <BottomButton
+            label="대기 중인 요청 확인하기"
+            acceptedCount={acceptedCount}
+            totalCount={totalCount}
+            onClick={() => {
+              router.push('/pending-request');
+            }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/public-profile/[id]/page.tsx
+++ b/src/app/public-profile/[id]/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
+import { useState } from 'react';
 
 import Avartar from '@/components/common/Avatar';
+import BottomButton from '@/components/common/BottomButton';
 import StudyExperienceCard from '@/components/common/StudyExperienceCard';
 import TagList from '@/components/common/TagList';
-import BottomButton from '@/components/common/BottomButton';
-import { useState } from 'react';
 
 interface StudyExperienceDatas {
   title: string;

--- a/src/app/public-profile/[id]/page.tsx
+++ b/src/app/public-profile/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 
 import Avartar from '@/components/common/Avatar';
 import BottomButton from '@/components/common/BottomButton';
+import NavHeader from '@/components/common/NavHeader';
 import StudyExperienceCard from '@/components/common/StudyExperienceCard';
 import TagList from '@/components/common/TagList';
 
@@ -73,39 +74,15 @@ const PublicProfile = () => {
     },
   };
 
-  const handleLeftClick = () => {
-    router.back();
-  };
   const handleAccept = () => {
     setAcceptedCount(acceptedCount + 1);
   };
   return (
     <div>
+      <NavHeader title="오픈 프로필" />
       <div className="flex justify-center min-h-screen pb-32 ">
         <div className="flex items-center flex-col w-[21.438rem] space-y-5">
           <div className="relative text-center space-y-5 ">
-            <div className="sticky top-0 flex items-center justify-center">
-              {/* 이전 단계로 이동 */}
-              <button onClick={handleLeftClick} className="fixed left-0">
-                <svg
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="cursor-pointer">
-                  <path
-                    fillRule="evenodd"
-                    clipRule="evenodd"
-                    d="M15.5303 3.96967C15.8232 4.26256 15.8232 4.73744 15.5303 5.03033L8.56066 12L15.5303 18.9697C15.8232 19.2626 15.8232 19.7374 15.5303 20.0303C15.2374 20.3232 14.7626 20.3232 14.4697 20.0303L6.96967 12.5303C6.67678 12.2374 6.67678 11.7626 6.96967 11.4697L14.4697 3.96967C14.7626 3.67678 15.2374 3.67678 15.5303 3.96967Z"
-                    fill="black"
-                    fillOpacity="0.8"
-                  />
-                </svg>
-              </button>
-
-              <div className="font-bold text-lg mx-auto">오픈 프로필</div>
-            </div>
             <div className="w-[6.25rem] h-[6.25rem] p-0 border-2 border-[#EADCF3] rounded-full">
               <Avartar size={'100%'} />
             </div>

--- a/src/components/common/NavHeader.tsx
+++ b/src/components/common/NavHeader.tsx
@@ -1,0 +1,32 @@
+interface NavHeaderProps {
+  title?: string;
+  handleLeftClick: () => void;
+}
+
+const NavHeader = ({ title, handleLeftClick }: NavHeaderProps) => {
+  return (
+    <div className="sticky top-0 flex items-center justify-center">
+      {/* 이전 단계로 이동 */}
+      <button onClick={handleLeftClick} className="fixed left-0">
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="cursor-pointer">
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M15.5303 3.96967C15.8232 4.26256 15.8232 4.73744 15.5303 5.03033L8.56066 12L15.5303 18.9697C15.8232 19.2626 15.8232 19.7374 15.5303 20.0303C15.2374 20.3232 14.7626 20.3232 14.4697 20.0303L6.96967 12.5303C6.67678 12.2374 6.67678 11.7626 6.96967 11.4697L14.4697 3.96967C14.7626 3.67678 15.2374 3.67678 15.5303 3.96967Z"
+            fill="black"
+            fillOpacity="0.8"
+          />
+        </svg>
+      </button>
+
+      <div className="font-bold text-lg mx-auto">{title}</div>
+    </div>
+  );
+};
+export default NavHeader;

--- a/src/components/common/NavHeader.tsx
+++ b/src/components/common/NavHeader.tsx
@@ -1,11 +1,18 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
 interface NavHeaderProps {
   title?: string;
-  handleLeftClick: () => void;
 }
 
-const NavHeader = ({ title, handleLeftClick }: NavHeaderProps) => {
+const NavHeader = ({ title }: NavHeaderProps) => {
+  const router = useRouter();
+  const handleLeftClick = () => {
+    router.back();
+  };
   return (
-    <div className="sticky top-0 flex items-center justify-center">
+    <div className="sticky  mb-5 h-[3.125rem] border-b-1 border-[#D9D9D9] flex items-center justify-center">
       {/* 이전 단계로 이동 */}
       <button onClick={handleLeftClick} className="fixed left-0">
         <svg


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

스터디 만들기에서 오픈프로필까지 공통으로 필요한 상단바 구현

## 🌱 구현 내용

-아이콘을 클릭하면 이전 페이지 라우팅
-title을 props 받아와 재사용 가능 

![image](https://github.com/user-attachments/assets/2c1870a9-b7f3-4d9c-b06e-57ab7952e8c5)


## ✅ check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
